### PR TITLE
fix(discord): 适度提高分享速率限制

### DIFF
--- a/deploy/discord-share-worker/README.md
+++ b/deploy/discord-share-worker/README.md
@@ -98,7 +98,9 @@ size errors remain unchanged for non-empty prompts.
 - KV only stores OAuth handoffs and bearer sessions. Per-share abuse protection
   uses Cloudflare's native Rate Limiting binding, so a successful share does not
   consume a KV write.
-- The Worker rate-limits each Discord user and validates the image MIME type.
+- The Worker allows each Discord user up to eight share requests per 60 seconds
+  and validates the image MIME type. This limit is intentionally per-user, so
+  a small increase does not remove burst or cross-account abuse protection.
   It does not impose an application-level image-size limit. The browser offers
   optional upload-copy compression above 20 MiB; choosing the original remains
   valid, while Cloudflare and Discord retain their own platform request limits.

--- a/deploy/discord-share-worker/share.js
+++ b/deploy/discord-share-worker/share.js
@@ -315,7 +315,7 @@ async function sendWebhookSequence(target, steps, filename) {
 	}
 }
 
-async function sendWebhook(target, payload, image, filename, promptFile = null) {
+export async function sendWebhook(target, payload, image, filename, promptFile = null) {
 	const webhook = new URL(target.url);
 	webhook.searchParams.set("wait", "true");
 	let response;

--- a/deploy/discord-share-worker/wrangler.toml.example
+++ b/deploy/discord-share-worker/wrangler.toml.example
@@ -12,7 +12,7 @@ name = "SHARE_RATE_LIMITER"
 namespace_id = "replace-with-unique-positive-integer"
 
   [ratelimits.simple]
-  limit = 5
+  limit = 8
   period = 60
 
 [vars]

--- a/tests/discord_share_worker.test.js
+++ b/tests/discord_share_worker.test.js
@@ -10,6 +10,7 @@ import worker, {
 	enforceRateLimit,
 	isAllowedOrigin,
 } from "../deploy/discord-share-worker/worker.js";
+import { sendWebhook } from "../deploy/discord-share-worker/share.js";
 
 test("relay accepts loopback origins and explicit production origins only", () => {
 	const env = { ALLOWED_ORIGINS: "https://comfy.example, https://studio.example" };
@@ -285,6 +286,21 @@ test("share rate limit rejection gives a clear retry contract", async () => {
 	);
 });
 
+test("eight concurrent shares pass, the ninth is rejected, and the next window recovers", async () => {
+	let remaining = 8;
+	const env = {
+		SHARE_RATE_LIMITER: {
+			limit: async () => ({ success: remaining-- > 0 }),
+		},
+	};
+
+	await Promise.all(Array.from({ length: 8 }, () => enforceRateLimit(env, "42")));
+	await assert.rejects(enforceRateLimit(env, "42"), (error) => error.code === "rate_limited");
+
+	remaining = 8;
+	await enforceRateLimit(env, "42");
+});
+
 test("rate limiter failures do not silently bypass abuse protection", async () => {
 	const cause = new Error("binding unavailable");
 	const env = {
@@ -303,14 +319,38 @@ test("rate limiter failures do not silently bypass abuse protection", async () =
 	);
 });
 
-test("Worker configuration binds native rate limiting and has no KV rate counter variable", () => {
+test("Worker configuration allows eight shares per user in each 60-second window", () => {
 	const config = readFileSync(
 		new URL("../deploy/discord-share-worker/wrangler.toml.example", import.meta.url),
 		"utf8",
 	);
 	assert.match(config, /\[\[ratelimits\]\][\s\S]*name = "SHARE_RATE_LIMITER"/);
-	assert.match(config, /\[ratelimits\.simple\][\s\S]*limit = 5[\s\S]*period = 60/);
+	assert.match(config, /\[ratelimits\.simple\][\s\S]*limit = 8[\s\S]*period = 60/);
 	assert.doesNotMatch(config, /RATE_LIMIT_PER_MINUTE/);
+});
+
+test("Discord webhook 429 responses wait for retry_after before retrying once", async () => {
+	const originalFetch = globalThis.fetch;
+	let requestCount = 0;
+	globalThis.fetch = async () => {
+		requestCount += 1;
+		if (requestCount === 1) {
+			return Response.json({ retry_after: 0 }, { status: 429 });
+		}
+		return Response.json({ id: "message-1", channel_id: "channel-1" });
+	};
+	try {
+		const message = await sendWebhook(
+			{ label: "Showcase", url: "https://discord.com/api/webhooks/100/token" },
+			{ embeds: [], attachments: [] },
+			null,
+			"result.png",
+		);
+		assert.equal(requestCount, 2);
+		assert.equal(message.id, "message-1");
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
 });
 
 test("authenticated clients receive public targets and multi-target shares keep complete ordered sequences", async () => {


### PR DESCRIPTION
## 变化
- 将 Discord 分享 Worker 的每用户额度从 5 次/60 秒调整为 8 次/60 秒
- 保留 Cloudflare 原生身份隔离、窗口限制和突发保护
- Discord webhook 官方 429 继续按 `retry_after` 等待重试
- 同步 Worker 示例配置和部署说明

## 客户端配套
- 对应 `Aaalice_NAI_Launcher` 分支 `Aaalice/relax-discord-share-rate-limit` 增加准确倒计时和并发重复保护

## 验证
- Worker 专项测试 17/17 通过
- 全量 `npm test` 723/723 通过
- `git diff --check origin/main...HEAD` 通过

## 部署
- 合并后仍需部署 Worker，新额度才会在线生效